### PR TITLE
Fix classic `strcpy` write into unallocated memory and deallocate stuff

### DIFF
--- a/callisto/insertables/module.h
+++ b/callisto/insertables/module.h
@@ -57,7 +57,7 @@ namespace callisto {
 
 		const fs::path project_relative_path;
 
-		std::vector<const char*> additional_include_paths;
+		std::vector<fs::path> additional_include_paths;
 
 		const fs::path callisto_asm_file;
 		std::unordered_set<int> other_module_addresses;

--- a/callisto/insertables/patch.h
+++ b/callisto/insertables/patch.h
@@ -25,7 +25,7 @@ namespace callisto {
 		static constexpr auto MAX_ROM_SIZE = 16 * 1024 * 1024;
 
 		const fs::path patch_path;
-		std::vector<const char*> additional_include_paths;
+		std::vector<fs::path> additional_include_paths;
 		std::vector<std::pair<size_t, size_t>> hijacks{};
 
 		std::unordered_set<ResourceDependency> determineDependencies() override;


### PR DESCRIPTION
Turns out I pulled a classic `new char[strlen]` instead of `new char[strlen+1]`, causing the null terminator to dangle into unallocated memory, potentially causing a heap corruption (I think, if something else is causing it that'd be wild at this point I think).

I also forgot to deallocate after the cstrings are no longer needed.

Both things should now be fixed.